### PR TITLE
Add jStat dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5680,6 +5680,11 @@
         "handlebars": "4.0.11"
       }
     },
+    "jStat": {
+      "version": "1.7.1",
+      "resolved": "https://registry.npmjs.org/jStat/-/jStat-1.7.1.tgz",
+      "integrity": "sha512-toueem/U5hyHM6pqe6OZOL/5P8MrY7Ss1K8Brg+TcfX+RAjDU/sbwy72fwzmLPQ5ykdBe1UEoWQHc7OSNWMUDQ=="
+    },
     "jest": {
       "version": "22.1.4",
       "resolved": "https://registry.npmjs.org/jest/-/jest-22.1.4.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -5683,7 +5683,8 @@
     "jStat": {
       "version": "1.7.1",
       "resolved": "https://registry.npmjs.org/jStat/-/jStat-1.7.1.tgz",
-      "integrity": "sha512-toueem/U5hyHM6pqe6OZOL/5P8MrY7Ss1K8Brg+TcfX+RAjDU/sbwy72fwzmLPQ5ykdBe1UEoWQHc7OSNWMUDQ=="
+      "integrity": "sha512-toueem/U5hyHM6pqe6OZOL/5P8MrY7Ss1K8Brg+TcfX+RAjDU/sbwy72fwzmLPQ5ykdBe1UEoWQHc7OSNWMUDQ==",
+      "dev": true
     },
     "jest": {
       "version": "22.1.4",

--- a/package.json
+++ b/package.json
@@ -40,5 +40,7 @@
     "webpack": "^3.10.0",
     "webpack-dev-server": "^2.11.0"
   },
-  "dependencies": {}
+  "dependencies": {
+    "jStat": "^1.7.1"
+  }
 }

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "d3-scale": "^1.0.7",
     "eslint": "^4.15.0",
     "eslint-config-google": "^0.9.1",
+    "jStat": "^1.7.1",
     "jest": "^22.1.4",
     "jstat": "^1.7.1",
     "prop-types": "^15.6.0",
@@ -40,7 +41,5 @@
     "webpack": "^3.10.0",
     "webpack-dev-server": "^2.11.0"
   },
-  "dependencies": {
-    "jStat": "^1.7.1"
-  }
+  "dependencies": {}
 }


### PR DESCRIPTION
Running from `git clone` will give this error:

```
$ npm run dev-server
> jsdemo@1.0.0 dev-server /home/louie/dev/iota/iotavisualization
> webpack-dev-server

Project is running at http://localhost:9000/
webpack output is served from /
Content not from webpack is served from /home/louie/dev/iota/iotavisualization/public
Hash: 1e605285264b77e08331
Version: webpack 3.10.0
Time: 2417ms
    Asset    Size  Chunks                    Chunk Names
bundle.js  1.8 MB       0  [emitted]  [big]  main
   [0] ./node_modules/react/index.js 190 bytes {0} [built]
   [8] ./node_modules/react-dom/index.js 1.36 kB {0} [built]
 [100] ./node_modules/react-redux/es/index.js 230 bytes {0} [built]
 [161] multi (webpack)-dev-server/client?http://localhost:9000 ./src/index.js 40 bytes {0} [built]
 [162] (webpack)-dev-server/client?http://localhost:9000 7.91 kB {0} [built]
 [163] ./node_modules/url/url.js 23.3 kB {0} [built]
 [169] (webpack)-dev-server/node_modules/strip-ansi/index.js 150 bytes {0} [built]
 [171] ./node_modules/loglevel/lib/loglevel.js 7.86 kB {0} [built]
 [172] (webpack)-dev-server/client/socket.js 1.08 kB {0} [built]
 [174] (webpack)-dev-server/client/overlay.js 3.67 kB {0} [built]
 [179] (webpack)/hot nonrecursive ^\.\/log$ 170 bytes {0} [built]
 [181] (webpack)/hot/emitter.js 77 bytes {0} [built]
 [183] ./src/index.js 1.9 kB {0} [built]
 [194] ./src/reducer.js 400 bytes {0} [built]
 [222] ./src/containers/TangleContainer.js 21.6 kB {0} [built]
    + 398 hidden modules

ERROR in ./src/shared/generateData.js
Module not found: Error: Can't resolve 'jStat' in '/home/louie/dev/iota/iotavisualization/src/shared'
 @ ./src/shared/generateData.js 6:12-28
 @ ./src/containers/TangleContainer.js
 @ ./src/index.js
 @ multi (webpack)-dev-server/client?http://localhost:9000 ./src/index.js
webpack: Failed to compile.
```

This PR add `jStat` as depencency.