### PR TITLE
Show tx cumulative weight when mouse hover

### DIFF
--- a/src/components/Tangle.js
+++ b/src/components/Tangle.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import Tooltip from 'rc-tooltip';
 import * as d3Scale from 'd3-scale';
 
 const Axis = ({x, endX, y, startVal, endVal, ticks}) => {
@@ -134,6 +135,13 @@ const Tangle = props =>
       </g>
       <g>
         {props.nodes.map(node =>
+          <Tooltip
+            visible={props.hoveredNode === node}
+            placement="top"
+            overlay={
+              <div>Cumulative weight: {props.hoveredNodeWeight}<br />
+              Score: {props.hoveredNodeScore}</div>}
+            >
           <g transform={`translate(${node.x},${node.y})`} key={node.name}
             className={
               `${props.approvedNodes.has(node) ? 'approved' :
@@ -141,11 +149,11 @@ const Tangle = props =>
                  props.tips.has(node) ? 'tip' : ''}`}>
             {props.hoveredNode === node &&
               <g style={{opacity: 0.4}}>
-                <Node nodeRadius={props.nodeRadius*1.9} />
-                <Node nodeRadius={props.nodeRadius*1.7} />
+                <Node nodeRadius={props.nodeRadius*1.6} />
+                <Node nodeRadius={props.nodeRadius*1.3} />
               </g>}
             <Node
-              nodeRadius={props.hoveredNode === node ? props.nodeRadius * 1.5 : props.nodeRadius}
+              nodeRadius={props.nodeRadius}
               name={node.name}
               mouseEntersNodeHandler={props.mouseEntersNodeHandler}
               mouseLeavesNodeHandler={props.mouseLeavesNodeHandler} />
@@ -154,9 +162,10 @@ const Tangle = props =>
               fill='#666' fontFamily='Helvetica'
               alignmentBaseline='middle' textAnchor='middle'
               pointerEvents='none'>
-              {props.hoveredNode === node ? 'C:' + props.hoveredNodeWeight : node.name}
+              {node.name}
             </text>}
-          </g>)}
+          </g>
+          </Tooltip>)}
       </g>
       <g>
         <Axis

--- a/src/components/Tangle.js
+++ b/src/components/Tangle.js
@@ -141,11 +141,11 @@ const Tangle = props =>
                  props.tips.has(node) ? 'tip' : ''}`}>
             {props.hoveredNode === node &&
               <g style={{opacity: 0.4}}>
-                <Node nodeRadius={props.nodeRadius*1.6} />
-                <Node nodeRadius={props.nodeRadius*1.3} />
+                <Node nodeRadius={props.nodeRadius*1.9} />
+                <Node nodeRadius={props.nodeRadius*1.7} />
               </g>}
             <Node
-              nodeRadius={props.nodeRadius}
+              nodeRadius={props.hoveredNode === node ? props.nodeRadius * 1.5 : props.nodeRadius}
               name={node.name}
               mouseEntersNodeHandler={props.mouseEntersNodeHandler}
               mouseLeavesNodeHandler={props.mouseLeavesNodeHandler} />
@@ -154,7 +154,7 @@ const Tangle = props =>
               fill='#666' fontFamily='Helvetica'
               alignmentBaseline='middle' textAnchor='middle'
               pointerEvents='none'>
-              {node.name}
+              {props.hoveredNode === node ? 'C:' + props.hoveredNodeWeight : node.name}
             </text>}
           </g>)}
       </g>

--- a/src/components/Tangle.js
+++ b/src/components/Tangle.js
@@ -137,6 +137,7 @@ const Tangle = props =>
         {props.nodes.map(node =>
           <Tooltip
             visible={props.hoveredNode === node}
+            key={node.name}
             placement="top"
             overlay={
               <div>Cumulative weight: {props.hoveredNodeWeight}<br />

--- a/src/components/Tangle.js
+++ b/src/components/Tangle.js
@@ -138,7 +138,7 @@ const Tangle = props =>
           <Tooltip
             visible={props.hoveredNode === node}
             key={node.name}
-            placement="top"
+            placement='top'
             overlay={
               <div>Cumulative weight: {props.hoveredNodeWeight}<br />
               Score: {props.hoveredNodeScore}</div>}

--- a/src/components/Tangle.js
+++ b/src/components/Tangle.js
@@ -196,6 +196,8 @@ Tangle.propTypes = {
   approvingNodes: PropTypes.any,
   approvingLinks: PropTypes.any,
   hoveredNode: PropTypes.any,
+  hoveredNodeWeight: PropTypes.any,
+  hoveredNodeScore: PropTypes.any
 };
 
 export default Tangle;

--- a/src/containers/TangleContainer.js
+++ b/src/containers/TangleContainer.js
@@ -397,6 +397,7 @@ class TangleContainer extends React.Component {
           approvingNodes={approving.nodes}
           approvingLinks={approving.links}
           hoveredNode={this.state.hoveredNode}
+          hoveredNodeWeight={approving.nodes.size + 1} // Assume each node weight is 1
           tips={getTips({
             nodes: this.state.nodes,
             links: this.state.links,

--- a/src/containers/TangleContainer.js
+++ b/src/containers/TangleContainer.js
@@ -398,6 +398,7 @@ class TangleContainer extends React.Component {
           approvingLinks={approving.links}
           hoveredNode={this.state.hoveredNode}
           hoveredNodeWeight={approving.nodes.size + 1} // Assume each node weight is 1
+          hoveredNodeScore={approved.nodes.size + 1}
           tips={getTips({
             nodes: this.state.nodes,
             links: this.state.links,


### PR DESCRIPTION
Using `approving.nodes` we can get the cumulative weight of the hovered transaction.

But this assume each transaction weight is 1, and it is unrelate to X axis time.